### PR TITLE
chore(ci): add workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ develop, master ]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   commitlint:
     if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' 


### PR DESCRIPTION
Potential fix for [https://github.com/nighcrawl/cv/security/code-scanning/1](https://github.com/nighcrawl/cv/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block so the `GITHUB_TOKEN` is constrained to the least privilege required. For these jobs, they only need to read repository contents and metadata for checkout and to inspect the PR’s SHAs; no writes are needed.

The single best fix is to add a workflow-level `permissions:` block right after the `on:` section (before `jobs:`) in `.github/workflows/ci.yml`. This will apply to all jobs that don’t override it. Set `contents: read` as suggested by CodeQL, and optionally add `pull-requests: read` to match the commitlint job’s use of PR data, while still staying read-only. No changes are needed inside individual jobs.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert a new `permissions:` section between lines 7 and 9 (after the `on:` block, before `jobs:`).
- Add:
  - `contents: read`
  - `pull-requests: read`

No additional imports or definitions are required; this is purely a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
